### PR TITLE
Generate hidden attacks if a discovery move is possible

### DIFF
--- a/generate/chessExt.js
+++ b/generate/chessExt.js
@@ -28,6 +28,20 @@ function isCheckAfterRemovingPieceAtSquare(fen, square) {
     return chess.in_check();
 }
 
+function isDiscoveryAfterMovingPieceAtSquare(fen, from, fromPiece, to, toPiece) {
+    var chess = new Chess();
+    chess.load(fen);
+    var pieces = piecesForColour(chess.turn());
+    pieces.forEach(from => {
+        var moves = movesOfPieceOn(square);
+        if (moves.filter(move => !canCapture(from, fromPiece, move.to, toPiece)).length > 0) {
+            chess.remove(square);
+            return canCapture(from, fromPiece, to, toPiece);
+        }
+    }
+    return false;
+}
+
 /**
  * Switch side to play (and remove en-passent information)
  */

--- a/generate/chessExt.js
+++ b/generate/chessExt.js
@@ -165,6 +165,7 @@ module.exports.piecesForColour = piecesForColour;
 module.exports.isCheckAfterPlacingKingAtSquare = isCheckAfterPlacingKingAtSquare;
 module.exports.fenForOtherSide = fenForOtherSide;
 module.exports.isCheckAfterRemovingPieceAtSquare = isCheckAfterRemovingPieceAtSquare;
+module.exports.isDiscoveryAfterMovingPieceAtSquare = isDiscoveryAfterMovingPieceAtSquare;
 module.exports.movesOfPieceOn = movesOfPieceOn;
 module.exports.majorPiecesForColour = majorPiecesForColour;
 module.exports.canCapture = canCapture;

--- a/generate/hiddenAttacks.js
+++ b/generate/hiddenAttacks.js
@@ -1,7 +1,7 @@
 /**
  * Enrich puzzle with pieces aligned with others.
  * 
- *
+ * Only include pieces if there is a discovery move.
  */
 
 var Chess = require('./lib/chess').Chess;
@@ -34,7 +34,8 @@ function addAligned(fen, features) {
             opponentsPieces.forEach(to => {
                 if (ChessExt.canCapture(from, chess.get(from), to, chess.get(to))) {
                     var availableOnBoard = moves.filter(m => m.from === from && m.to === to);
-                    if (availableOnBoard.length === 0) {
+                    if (availableOnBoard.length === 0 &&
+                        ChessExt.isDiscoveryAfterMovingPieceAtSquare(fen, from, chess.get(from), to, chess.get(to))) {
                         aligned.push(from);
                     }
                 }


### PR DESCRIPTION
Pin detection already works (and does not need to consider the following).

Discovery detection should consider whether the in-between piece has a pseudo-legal (i.e. legal if ignoring check) move which causes a discovery.  This change should work in 99.9% of positions (but not in the 0.1% where an en passant move causes a discovery across the 4th/5th rank).